### PR TITLE
Add library.json to enable gas library for esp-idf

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,35 @@
+{
+  "name": "Sensirion Gas Index Algorithm",
+  "version": "3.1.0",
+  "description": "Library for gas index algorithm to use with Sensirion sensors. Enables you to calculate gas index from raw signal.",
+  "keywords": "SensirionGasIndexAlgorithm, VOCGasIndexAlgorithm, NOxGasIndexAlgorithm, SensirionI2CSht4x, SensirionI2CSgp41, sgp41, sgp40, voc_algorithm, nox_algorithm",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Sensirion/arduino-gas-index-algorithm.git"
+  },
+  "authors": [
+    {
+      "name": "Sensirion",
+      "email": "info@sensirion.com",
+      "url": "https://github.com/Sensirion/arduino-gas-index-algorithm",
+      "maintainer": true
+    }
+  ],
+  "license": "BSD 3-Clause License",
+  "homepage": "https://sensirion.com",
+  "headers": [
+    "NOxGasIndexAlgorithm.h",
+    "VOCGasIndexAlgorithm.h"
+  ],
+  "examples": [
+    {
+      "name": "ExampleUsage",
+      "base": "examples/exampleUsage",
+      "files": [
+        "exampleUsage.ino"
+      ]
+    }
+  ],
+  "frameworks": "*",
+  "platforms": "*"
+}


### PR DESCRIPTION
Since the library has no dependency on Arduino it can be used from esp-idf (or other frameworks) as well.
Currently platformio marks the library as incompatible with esp-idf because no library.json exists.  If  there is only library.properties pio assumes a dependency on Arduino.
Some of the values in library.json are just educated guesses but I'm sure the intend is clear.

Context: I'm currently adding support for SGP41 to [esphome ](https://esphome.io)
Because esphome recently added support for esp-idf making this library compatible saves me from copying this code and add a library reference instead.    
The [existing code](https://github.com/esphome/esphome/tree/dev/esphome/components/sgp40)  uses a modified version of an older version of your code. 
My[ new code](https://github.com/martgras/esphome/tree/sgp41/esphome/components/sgp4x) just references this library (or my fork currently) 

If you are familiar with esphome you can use this config for testing
```yaml
external_components:
  - source: github://martgras/esphome@sgp41
    components: ["sgp4x"]
esphome:
  name: test-sgp41
esp32:
  board: pico32
  framework:
    type: esp-idf
logger:
  level: DEBUG
i2c:
  - id: bus_a
    sda: 22
    scl: 21
    scan: True
sensor:
  - platform: sgp4x
    voc:
      name: "VOC Index"
      id: sgp41_voc_index
    nox:
      name: "NOx"
    compensation:
      humidity_source: sht41_humidity
      temperature_source: sht41_temperature
    update_interval: 5s
  - platform: sht4x
    temperature:
      name: "SHT41 Temperature"
      id: sht41_temperature
    humidity:
      name: "sht 41 Relative Humidity"
      id: sht41_humidity
    update_interval: 15s
wifi:
  ssid: !secret wifi_sid
  password: !secret wifi_password
```
